### PR TITLE
r13006 - Undefined index - fix

### DIFF
--- a/CRM/Mailing/Transactional.php
+++ b/CRM/Mailing/Transactional.php
@@ -283,6 +283,7 @@ class CRM_Mailing_Transactional {
       $recipient->save();
 
       // open tracking
+      $params['html'] = CRM_Utils_Array::value('html', $params, '');
       $params['html'] .= "\n" . '<img src="' . $config->userFrameworkResourceURL .
         "extern/open.php?q=$event_queue_id\" width='1' height='1' alt='' border='0'>";
 


### PR DESCRIPTION
Notice error is displayed if `html` is not contained in `$params`.

Notice: Undefined index: html in CRM_Mailing_Transactional->verpify() (line 287 of /srv/www/stbedes/stbedes.fudev.co.nz/sites/default/files/civicrm/ext/nz.co.fuzion.transactional/CRM/Mailing/Transactional.php).

