### PR TITLE
Bail out if no returnPath set.

### DIFF
--- a/CRM/Mailing/Transactional.php
+++ b/CRM/Mailing/Transactional.php
@@ -80,8 +80,11 @@ class CRM_Mailing_Transactional {
    * @return voic
    */
   public function delivered($params) {
-    $parts = explode(CRM_Core_Config::singleton()->verpSeparator, $params['returnPath']);
+    if (!isset($params['returnPath'])) {
+      return;
+    }
 
+    $parts = explode(CRM_Core_Config::singleton()->verpSeparator, $params['returnPath']);
     $delivered = new CRM_Mailing_Event_BAO_Delivered();
     $delivered->event_queue_id = $parts[2];
     $delivered->time_stamp = date('YmdHis');


### PR DESCRIPTION
This was triggering an E_NOTICE when not set (test case was sending receipt from contribution page).

Refs #12

Not merging yet because I want to better understand *why* this happens before we work around it.