### PR TITLE
#21 - include subject for schedule reminder transactional mails

### DIFF
--- a/CRM/Mailing/Transactional.php
+++ b/CRM/Mailing/Transactional.php
@@ -327,11 +327,11 @@ class CRM_Mailing_Transactional {
           VALUES ({$event_queue_id}, {$params['receipt_activity_id']})";
         CRM_Core_DAO::executeQuery($insertSQL);
       }
-
-      if (!empty($params['entity_id']) && !empty($params['groupName']) && !empty($event_queue_id)) {
+      $entityId = self::getEntityId($params);
+      if (!empty($entityId) && !empty($params['groupName']) && !empty($event_queue_id)) {
         CRM_Core_DAO::executeQuery("INSERT INTO civicrm_transactional_mapping
           (entity_id, option_group_name, mailing_event_queue_id) VALUES
-          ({$params['entity_id']}, '{$params['groupName']}', {$event_queue_id})");
+          ({$entityId}, '{$params['groupName']}', {$event_queue_id})");
       }
 
       // open tracking
@@ -360,6 +360,25 @@ class CRM_Mailing_Transactional {
       }
       $params['html'] = str_replace($urls, $new, $params['html']);
     }
+  }
+
+  /**
+   * @param array $params
+   *
+   * @return integer
+   */
+  public static function getEntityId($params) {
+    if ($params['groupName'] == 'msg_tpl_workflow_case'
+      && !empty($params['tplParams']['contact']) && !empty($params['tplParams']['contact']['activity_id'])) {
+      return $params['tplParams']['contact']['activity_id'];
+    }
+    elseif ($params['groupName'] == 'Activity Email Sender') {
+      $dao = CRM_Core_DAO::executeQuery("SELECT MAX(id) as activity_id FROM civicrm_activity");
+      if ($dao->fetch()) {
+        return $dao->activity_id;
+      }
+    }
+    return CRM_Utils_Array::value('entity_id', $params);
   }
 
 }

--- a/CRM/Mailing/Transactional.php
+++ b/CRM/Mailing/Transactional.php
@@ -328,6 +328,12 @@ class CRM_Mailing_Transactional {
         CRM_Core_DAO::executeQuery($insertSQL);
       }
 
+      if (!empty($params['entity_id']) && !empty($params['groupName']) && !empty($event_queue_id)) {
+        CRM_Core_DAO::executeQuery("INSERT INTO civicrm_transactional_mapping
+          (entity_id, option_group_name, mailing_event_queue_id) VALUES
+          ({$params['entity_id']}, '{$params['groupName']}', {$event_queue_id})");
+      }
+
       // open tracking
       $params['html'] = CRM_Utils_Array::value('html', $params, '');
       $params['html'] .= "\n" . '<img src="' . $config->userFrameworkResourceURL .
@@ -341,7 +347,7 @@ class CRM_Mailing_Transactional {
       foreach ($urls as $url) {
         $parts = parse_url(substr($url, 6, -1));
         // don't track things like mailto: and tel:
-        if (strpos($parts['scheme'], 'http') === 0) {
+        if (isset($parts['scheme']) && strpos($parts['scheme'], 'http') === 0) {
           // CiviMail doesn't track URLs that include tokens
           // by time we get the message token replacement has already happend
           // so we decide based on the presence of certain query vars, e.g. contact id or checksum

--- a/CRM/Transactional/Upgrader.php
+++ b/CRM/Transactional/Upgrader.php
@@ -162,4 +162,17 @@ class CRM_Transactional_Upgrader extends CRM_Transactional_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_4702() {
+    $this->ctx->log->info('Applying update 4702');
+     CRM_Core_DAO::executeQuery('CREATE TABLE `civicrm_transactional_mapping` (
+      `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+      `entity_id` int(11) DEFAULT NULL,
+      `option_group_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+      `mailing_event_queue_id` int(11) DEFAULT NULL,
+        PRIMARY KEY (`id`)
+      ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+    ');
+    return TRUE;
+  }
+
 }

--- a/transactional.php
+++ b/transactional.php
@@ -17,6 +17,45 @@ function transactional_civicrm_alterMailParams(&$params, $context) {
 }
 
 /**
+ * Implements hook_civicrm_alterReportVar().
+ *
+ * @link https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterReportVar
+ */
+function transactional_civicrm_alterReportVar($varType, &$var, &$object) {
+  if (is_a($object, 'CRM_Report_Form_Mailing_Detail')) {
+    if ($varType == 'sql') {
+      $var->_columnHeaders['mailing_queue_id'] = array(
+        'type' => 1,
+        'title' => 'Mailing Queue id',
+      );
+      $var->_select .= ", civicrm_mailing_event_queue.id as mailing_queue_id";
+    }
+    if ($varType == 'rows') {
+      foreach ($var as $key => $value) {
+        $tableName = '';
+        if (empty($value['civicrm_mailing_mailing_subject']) && CRM_Utils_String::startsWith($value['civicrm_mailing_mailing_name'], 'Transactional Email')) {
+          $mailName = explode("Transactional Email", $value['civicrm_mailing_mailing_name']);
+          $transactionalType = trim($mailName[1], "( )");
+
+          //If transactional mail is a schedule reminder.
+          if ($transactionalType == 'Scheduled Reminder Sender') {
+            $dao = CRM_Core_DAO::executeQuery("
+              SELECT entity_id
+              FROM civicrm_transactional_mapping
+              WHERE mailing_event_queue_id = {$value['mailing_queue_id']} AND option_group_name = '{$transactionalType}'"
+            );
+            if ($dao->fetch()) {
+              $var[$key]['civicrm_mailing_mailing_subject'] = CRM_Core_DAO::singleValueQuery("SELECT subject FROM civicrm_action_schedule WHERE id = {$dao->entity_id}");
+            }
+          }
+
+        }
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_civicrm_postEmailSend().
  *
  * Mark mail as delivered.
@@ -110,6 +149,14 @@ function transactional_civicrm_install() {
     `receipt_activity_id` int(10)    COMMENT \'Activity id of the receipt.\',
       PRIMARY KEY ( `id` )
     )  ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci  ;
+  ');
+  CRM_Core_DAO::executeQuery('CREATE TABLE `civicrm_transactional_mapping` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `entity_id` int(11) DEFAULT NULL,
+    `option_group_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+    `mailing_event_queue_id` int(11) DEFAULT NULL,
+      PRIMARY KEY (`id`)
+    ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
   ');
 
   civicrm_api3('OptionValue', 'create', array(


### PR DESCRIPTION
This change adds a subject display on Mailing Detail Report as per the requirement of https://github.com/fuzionnz/nz.co.fuzion.transactional/issues/21.

@lcdservices Currently, it only supports the display of Schedule Reminder Emails that is recorded as Transactional by this extension. To test this -

- Apply this patch and execute the upgrade on the Extension page. It adds a new table `civicrm_transactional_mapping` to map the group name with the entity that is sent. Eg Action Schedule id.

- Create a Sched Reminder for Membership, Contribution, etc and send it to a contact by executing the "Send Schedule Reminder" job.

- Check the Mailing Report. It should now display the subject of the reminder that was sent to the user.

Let us know if you want this ext. to show the subject for other transactional emails too, eg contribution receipt, membership receipt, etc. 

Thanks.