### PR TITLE
Intro to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Transactional Mail - Bounce and Tracking Handler
+# Transactional Mail
 
-This extension adds bounce handling to CiviCRM's transactional emails and creates Activities for mail such as Receipts and Invoices, which by default are not tracked in CiviCRM.
-
-CiviCRM by default only performs bounce handling when sending via CiviMail, but not when sending transactional emails such as scheduled reminders, event registrations, contribution receipts and the like. This extension addresses that limitation.
+This extension adds **bounce handling** and **click tracking**, and **creates activities** for CiviCRM's transactional emails (i.e event registrations, contribution receipts, invoices, scheduled reminders, and so on).
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This extension adds **bounce handling** and **click tracking**, and **creates activities** for CiviCRM's transactional emails (i.e event registrations, contribution receipts, invoices, scheduled reminders, and so on).
 
+Out of the box, CiviCRM only does the things mentioned above when sending via CiviMail. This extension adds that functionality to all mail sent from CiviCRM.
+
 ## Author
 
 This extension was initially written by Dave Reedy on behalf of [Fuzion](https://www.fuzion.co.nz) and substantially extended by Jitendra Purohit.


### PR DESCRIPTION
Improved the intro to the readme, making it clearer that the extension adds activities for transactional email since I think it is an important feature, currently overlooked.