### PR TITLE
Honor core default setting for click-tracking and open-tracking

### DIFF
--- a/CRM/Mailing/Transactional.php
+++ b/CRM/Mailing/Transactional.php
@@ -192,8 +192,6 @@ class CRM_Mailing_Transactional {
         'unsubscribe_id' => NULL,
         'resubscribe_id' => NULL,
         'optout_id' => NULL,
-        'url_tracking' => 1,
-        'open_tracking' => 1,
         'is_completed' => 1,
         'override_verp' => 0,
         'visibility' => 'User and User Admin Only',


### PR DESCRIPTION
Rather than forcibly turning on click-tracking and open-tracking, this extension should honor the new core default configuration for these settings.  See https://github.com/civicrm/civicrm-core/pull/17291