### PR TITLE
Account for deprecation of groupName param

### DIFF
--- a/CRM/Transactional/Upgrader.php
+++ b/CRM/Transactional/Upgrader.php
@@ -180,4 +180,20 @@ class CRM_Transactional_Upgrader extends CRM_Transactional_Upgrader_Base {
     return TRUE;
   }
 
+  /*
+   * Adds additional column to civicrm_transactional_mapping to
+   * account for depreciation of passing of group name in favour of value name
+   */
+  public function upgrade_4704() {
+    $this->ctx->log->info('Applying update 4704');
+    CRM_Core_DAO::executeQuery(
+        'ALTER TABLE `civicrm_transactional_mapping`
+         ADD COLUMN
+        `option_value_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL
+        AFTER `option_group_name`;
+      ');
+    return TRUE;
+
+  }
+
 }

--- a/transactional.php
+++ b/transactional.php
@@ -10,7 +10,7 @@ require_once 'transactional.civix.php';
  * @link https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterMailParams
  */
 function transactional_civicrm_alterMailParams(&$params, $context) {
-  if ($context == 'civimail' || !isset($params['groupName'])) {
+  if ($context == 'civimail' || (!isset($params['groupName']) && !isset($params['valueName']))) {
     return;
   }
   CRM_Mailing_Transactional::singleton()->verpify($params);


### PR DESCRIPTION
Before: 

If groupName needs to be set for emails to have bounce processing and tracking added.
Mailings are grouped together based on the "Group Name" 

After:
Either valueName or groupName needs to be set emails to have bounce processing and tracking added.
Mailings are grouped together based on the "Value Name" - note this means that mailings are broken down by template as opposed to grouping of message templates. For example offline and online receipts will be tracked separately. 

On upgrade we're not breaking down previous emails by value name. 

Outstanding:
If we merge this we will also need to account for treatment in reports. 