### PR TITLE
Remove groupName dependency and use workflow

### DIFF
--- a/CRM/Mailing/Report.php
+++ b/CRM/Mailing/Report.php
@@ -58,11 +58,11 @@ class CRM_Mailing_Report {
         $mailName = explode("Transactional Email", $value['civicrm_mailing_mailing_name']);
         $transactionalType = trim($mailName[1], "( )");
 
-        if (in_array($transactionalType, ['Scheduled Reminder Sender', 'msg_tpl_workflow_case', 'Activity Email Sender'])) {
+        if (in_array($transactionalType, ['Scheduled Reminder Sender', 'case_activity', 'Activity Email Sender'])) {
           $dao = CRM_Core_DAO::executeQuery("
             SELECT entity_id
             FROM civicrm_transactional_mapping
-            WHERE mailing_event_queue_id = {$value['mailing_queue_id']} AND option_group_name = '{$transactionalType}'"
+            WHERE mailing_event_queue_id = {$value['mailing_queue_id']} AND mailing_name = '{$transactionalType}'"
           );
           if ($dao->fetch()) {
             $tableName = 'civicrm_activity';

--- a/CRM/Transactional/BAO/RecipientReceipt.php
+++ b/CRM/Transactional/BAO/RecipientReceipt.php
@@ -46,12 +46,12 @@ class CRM_Transactional_BAO_RecipientReceipt extends CRM_Transactional_DAO_Recip
     if (Civi::settings()->get('invoice_is_email_pdf') && !empty($params['PDFFilename']) && empty($params['isEmailPdf'])) {
       return;
     }
-    if (empty($params['receipt_activity_id']) && !empty($params['valueName'])) {
-      $valueName = explode('_', $params['valueName']);
+    if (empty($params['receipt_activity_id']) && !empty($params['workflow'])) {
+      $workflow = explode('_', $params['workflow']);
 
-      if (!empty($valueName[2]) && $valueName[2] == 'receipt') {
+      if (!empty($workflow[2]) && $workflow[2] == 'receipt') {
         $activityParams = array(
-          'subject' => ts('Receipt Email initiated for %1 template.', [1 => $params['valueName']]),
+          'subject' => ts('Receipt Email initiated for %1 template.', [1 => $params['workflow']]),
           'source_contact_id' => CRM_Utils_Array::value('contactId', $params),
           'activity_type_id' => "ReceiptActivity",
           'source_record_id' => CRM_Utils_Array::value('contributionId', $params),

--- a/CRM/Transactional/Upgrader.php
+++ b/CRM/Transactional/Upgrader.php
@@ -180,4 +180,11 @@ class CRM_Transactional_Upgrader extends CRM_Transactional_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_4704() {
+    if (CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_transactional_mapping', 'option_group_name')) {
+      CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_transactional_mapping CHANGE option_group_name mailing_name varchar(255)');
+    }
+    return TRUE;
+  }
+
 }

--- a/tests/phpunit/CRM/Transactional/MailingTest.php
+++ b/tests/phpunit/CRM/Transactional/MailingTest.php
@@ -171,7 +171,7 @@ class CRM_Transactional_MailingTest extends PHPUnit\Framework\TestCase implement
     $transactionalMapping = "SELECT * FROM civicrm_transactional_mapping";
     $dao = CRM_Core_DAO::executeQuery($transactionalMapping);
     if ($dao->fetch()) {
-      $this->assertEquals('Scheduled Reminder Sender', $dao->option_group_name);
+      $this->assertEquals('Scheduled Reminder Sender', $dao->mailing_name);
       $this->assertEquals($actionSched['id'], $dao->entity_id);
     }
   }
@@ -224,17 +224,17 @@ class CRM_Transactional_MailingTest extends PHPUnit\Framework\TestCase implement
     // Test mailing has been created
     $mailing = civicrm_api3('Mailing', 'get', [
       'sequential' => 1,
-      'name' => ['=' => "Transactional Email (msg_tpl_workflow_contribution)"],
+      'name' => ['=' => "Transactional Email (contribution_online_receipt)"],
     ]);
-    $this->assertEquals(1, $mailing['count'], "expected 1 mailing with name: Transactional Email (msg_tpl_workflow_contribution) found: {$mailing['count']}");
+    $this->assertEquals(1, $mailing['count'], "expected 1 mailing with name: Transactional Email (contribution_online_receipt) found: {$mailing['count']}");
 
     // Test the mailing was updated recently
     $result = civicrm_api3('Mailing', 'get', [
       'sequential' => 1,
-      'name' => ['=' => "Transactional Email (msg_tpl_workflow_contribution)"],
+      'name' => ['=' => "Transactional Email (contribution_online_receipt)"],
       'modified_date' => ['>=' => $modified_date],
     ]);
-    $this->assertEquals(1, $mailing['count'], "expected 1 mailing updated since $modified_date with name: Transactional Email (msg_tpl_workflow_contribution) found: {$mailing['count']}");
+    $this->assertEquals(1, $mailing['count'], "expected 1 mailing updated since $modified_date with name: Transactional Email (contribution_online_receipt) found: {$mailing['count']}");
   }
 
 }

--- a/transactional.php
+++ b/transactional.php
@@ -10,7 +10,7 @@ require_once 'transactional.civix.php';
  * @link https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterMailParams
  */
 function transactional_civicrm_alterMailParams(&$params, $context) {
-  if ($context == 'civimail' || !isset($params['groupName'])) {
+  if ($context == 'civimail') {
     return;
   }
   CRM_Mailing_Transactional::singleton()->verpify($params);
@@ -181,7 +181,7 @@ function transactional_civicrm_install() {
   CRM_Core_DAO::executeQuery('CREATE TABLE IF NOT EXISTS `civicrm_transactional_mapping` (
     `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
     `entity_id` int(11) DEFAULT NULL,
-    `option_group_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+    `mailing_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
     `mailing_event_queue_id` int(11) DEFAULT NULL,
       PRIMARY KEY (`id`)
     ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;


### PR DESCRIPTION
Remove `groupName` dependency and use `workflow`. 

With the new extension upgrade - each workflow/message template will have a separate transactional mailing created in civi. So eg contribution online, offline and invoice templates will have separate mailings created to track open & clickthoughs.

Activities and schedule reminder don't have a workflow name,  so a separate transactional mailing is created for both entities.

Previous transactional mailing with option group name will not be used and are kept as it is.

Test executes fine with this PR.

```
$ phpunit6 tests/phpunit/CRM/Transactional/MailingTest.php
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

Parsing schema description /Users/jitendra/src/civicrm/xml/schema/Schema.xml
Extracting database information
Extracting table information
...                                                                 3 / 3 (100%)

Time: 6.87 seconds, Memory: 62.50MB

OK (3 tests, 12 assertions)
```