### PR TITLE
Remove call to Deprecated function CRM_Core_Form::getLoggedInContactID

### DIFF
--- a/transactional.php
+++ b/transactional.php
@@ -140,7 +140,7 @@ function transactional_civicrm_buildForm($formName, &$form) {
 
   $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $form);
   if (empty($contactId)) {
-    $contactId = !empty($form->_contactID) ? $form->_contactID : $form->getLoggedInUserContactID();
+    $contactId = !empty($form->_contactID) ? $form->_contactID : CRM_Core_Session::getLoggedInContactID();
   }
   CRM_Mailing_Transactional::singleton()->setFormContact($contactId);
 }


### PR DESCRIPTION
This replaces as per https://github.com/civicrm/civicrm-core/pull/20321
Note the replacement function can return NULL.
It seems like the code that retrieves the value already handles this.