### PR TITLE
Check value in old param if latest workflow is empty

### DIFF
--- a/CRM/Mailing/Transactional.php
+++ b/CRM/Mailing/Transactional.php
@@ -251,7 +251,7 @@ class CRM_Mailing_Transactional {
    * @return string $mailingName
    */
   protected function getMailingName($params) {
-    $mailingName = $params['workflow'] ?? NULL;
+    $mailingName = $params['workflow'] ?? $params['valueName'] ?? NULL;
     // Is this a normal email activity or a reminder email.
     if (!empty($params['groupName']) && in_array($params['groupName'], ['Scheduled Reminder Sender', 'Activity Email Sender'])) {
       $mailingName = $params['groupName'];
@@ -282,7 +282,6 @@ class CRM_Mailing_Transactional {
     if (empty($mailingName) || $mailingName == 'UNKNOWN') {
       return;
     }
-
     if (Civi::settings()->get('create_activities')) {
       CRM_Transactional_BAO_RecipientReceipt::initiateReceipt($params);
     }

--- a/CRM/Transactional/BAO/RecipientReceipt.php
+++ b/CRM/Transactional/BAO/RecipientReceipt.php
@@ -46,12 +46,13 @@ class CRM_Transactional_BAO_RecipientReceipt extends CRM_Transactional_DAO_Recip
     if (Civi::settings()->get('invoice_is_email_pdf') && !empty($params['PDFFilename']) && empty($params['isEmailPdf'])) {
       return;
     }
-    if (empty($params['receipt_activity_id']) && !empty($params['workflow'])) {
-      $workflow = explode('_', $params['workflow']);
+    $workflowName = $params['workflow'] ?? $params['valueName'] ?? NULL;
+    if (empty($params['receipt_activity_id']) && !empty($workflowName)) {
+      $workflow = explode('_', $workflowName);
 
       if (!empty($workflow[2]) && $workflow[2] == 'receipt') {
         $activityParams = array(
-          'subject' => ts('Receipt Email initiated for %1 template.', [1 => $params['workflow']]),
+          'subject' => ts('Receipt Email initiated for %1 template.', [1 => $workflowName]),
           'source_contact_id' => CRM_Utils_Array::value('contactId', $params),
           'activity_type_id' => "ReceiptActivity",
           'source_record_id' => CRM_Utils_Array::value('contributionId', $params),


### PR DESCRIPTION
Got few complaints where the workflow is empty and has valueName in the params, Fix here checks for both the params to retrieve the workflow value.