### PR TITLE
Make open tracking work on drupal 8

### DIFF
--- a/CRM/Mailing/Transactional.php
+++ b/CRM/Mailing/Transactional.php
@@ -355,8 +355,7 @@ class CRM_Mailing_Transactional {
 
       // open tracking
       $params['html'] = CRM_Utils_Array::value('html', $params, '');
-      $params['html'] .= "\n" . '<img src="' . $config->userFrameworkResourceURL .
-        "extern/open.php?q=$event_queue_id\" width='1' height='1' alt='' border='0'>";
+      $params['html'] .= "\n" . '<img src="' . CRM_Utils_System::externUrl('extern/open', "q=$event_queue_id") . "\" width='1' height='1' alt='' border='0'>";
 
       // click tracking - it's a little more involved
       // first we find all href attributes in the HTML


### PR DESCRIPTION
See https://github.com/civicrm/civicrm-core/blob/6425574fdac511ec588e01f6cc8b5a780bbed2dd/CRM/Mailing/BAO/Mailing.php#L1151 which is for all CMS's.

`extern` scripts don't exist on drupal 8, and as I understand are mostly deprecated.