### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Mailing/Transactional.php
+++ b/CRM/Mailing/Transactional.php
@@ -103,7 +103,7 @@ class CRM_Mailing_Transactional {
    */
   public function getContactAndEmailIds($params) {
     // if being sent from a message template, the contactId may already be there
-    $contact_id = CRM_Utils_Array::value('contactId', $params);
+    $contact_id = $params['contactId'] ?? NULL;
     if ($contact_id) {
       try {
         $email = civicrm_api3('Email', 'getsingle', [
@@ -398,7 +398,7 @@ class CRM_Mailing_Transactional {
         return $dao->activity_id;
       }
     }
-    return CRM_Utils_Array::value('entity_id', $params);
+    return $params['entity_id'] ?? NULL;
   }
 
 }

--- a/CRM/Transactional/BAO/RecipientReceipt.php
+++ b/CRM/Transactional/BAO/RecipientReceipt.php
@@ -14,7 +14,7 @@ class CRM_Transactional_BAO_RecipientReceipt extends CRM_Transactional_DAO_Recip
     $entityName = 'RecipientReceipt';
     $hook = empty($params['id']) ? 'create' : 'edit';
 
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
     $instance = new $className();
     $instance->copyValues($params);
     $instance->save();
@@ -53,16 +53,16 @@ class CRM_Transactional_BAO_RecipientReceipt extends CRM_Transactional_DAO_Recip
       if (!empty($workflow[2]) && $workflow[2] == 'receipt') {
         $activityParams = array(
           'subject' => ts('Receipt Email initiated for %1 template.', [1 => $workflowName]),
-          'source_contact_id' => CRM_Utils_Array::value('contactId', $params),
+          'source_contact_id' => $params['contactId'] ?? NULL,
           'activity_type_id' => "ReceiptActivity",
-          'source_record_id' => CRM_Utils_Array::value('contributionId', $params),
+          'source_record_id' => $params['contributionId'] ?? NULL,
           'status_id' => "Scheduled",
         );
         if (!empty($params['tplParams']) && !empty($params['tplParams']['contactID'])) {
           $activityParams['target_contact_id'] = $params['tplParams']['contactID'];
         }
         else {
-          $activityParams['target_contact_id'] = CRM_Utils_Array::value('contactId', $params);
+          $activityParams['target_contact_id'] = $params['contactId'] ?? NULL;
         }
 
         $id = CRM_Core_Session::getLoggedInContactID();
@@ -84,7 +84,7 @@ class CRM_Transactional_BAO_RecipientReceipt extends CRM_Transactional_DAO_Recip
     $activityParams = [
       'id' => $params['receipt_activity_id'],
       'subject' => 'Receipt Sent - ' .  CRM_Utils_Array::value('subject', $params),
-      'details' => CRM_Utils_Array::value('html', $params),
+      'details' => $params['html'] ?? NULL,
       'status_id' => 'Completed',
     ];
     civicrm_api3('activity', 'create', $activityParams);

--- a/CRM/Transactional/Form/TransactionalSettings.php
+++ b/CRM/Transactional/Form/TransactionalSettings.php
@@ -39,7 +39,7 @@ class CRM_Transactional_Form_TransactionalSettings extends CRM_Core_Form {
 
   public function postProcess() {
     $values = $this->exportValues();
-    Civi::settings()->set('create_activities', CRM_Utils_Array::value('create_activities', $values));
+    Civi::settings()->set('create_activities', $values['create_activities'] ?? NULL);
     CRM_Core_Session::setStatus(E::ts('You settings are saved.'), 'Success', 'success');
 
     parent::postProcess();


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.