### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Mailing/Transactional.php
+++ b/CRM/Mailing/Transactional.php
@@ -115,7 +115,7 @@ class CRM_Mailing_Transactional {
           ],
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $contact_id = NULL;
       }
     }
@@ -133,7 +133,7 @@ class CRM_Mailing_Transactional {
             ],
           ]);
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           $contact_id = NULL;
         }
       }
@@ -150,7 +150,7 @@ class CRM_Mailing_Transactional {
         ]);
         $contact_id = $email['contact_id'];
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $contact_id = NULL;
       }
     }
@@ -175,7 +175,7 @@ class CRM_Mailing_Transactional {
           'id' => $this->mailings[$name]['job_id']
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         unset($this->mailings[$name]);
       }
     }

--- a/api/v3/RecipientReceipt.php
+++ b/api/v3/RecipientReceipt.php
@@ -18,7 +18,7 @@ function _civicrm_api3_recipient_receipt_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_recipient_receipt_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -29,7 +29,7 @@ function civicrm_api3_recipient_receipt_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_recipient_receipt_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -40,7 +40,7 @@ function civicrm_api3_recipient_receipt_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_recipient_receipt_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.