### PR TITLE
Fixed issue mailing_id should be passed into EventQueue

### DIFF
--- a/CRM/Mailing/Transactional.php
+++ b/CRM/Mailing/Transactional.php
@@ -297,6 +297,7 @@ class CRM_Mailing_Transactional {
         'job_id' => $job_id,
         'email_id' => $email_id,
         'contact_id' => $contact_id,
+        'mailing_id' => $mailing_id,
         'hash' => $hash,
       ]);
       $event_queue_id = $api['id'];


### PR DESCRIPTION
Fix for error : 
User deprecated function: mailing_id should be passed into EventQueue create calls. Temporary handling has set it for now Caller: ::_civicrm_api3_basic_create in CRM_Core_Error::deprecatedWarning() (line 1144 of /vendor/civicrm/civicrm-core/CRM/Core/Error.php)